### PR TITLE
Updated the log

### DIFF
--- a/retriever/generate_dense_embeddings.py
+++ b/retriever/generate_dense_embeddings.py
@@ -91,7 +91,7 @@ def gen_ctx_vectors(
                 [(ctx_ids[i], out[i].view(-1).numpy()) for i in range(out.size(0))]
             )
 
-        if total % 10 == 0:
+        if total % bsz == 0:
             logger.info("Encoded passages %d", total)
     return results
 


### PR DESCRIPTION
Currently, the logger is set to log every 10 passages encoded, which might be too frequent and can clutter the logs if the batch size is large. Instead of logging every 10 passages can log every batch, which is be more reasonable.

